### PR TITLE
記事が特定以上の長さになるとプレビューされなくなる問題を修正。

### DIFF
--- a/src/Hinata/Controllers/DraftController.cs
+++ b/src/Hinata/Controllers/DraftController.cs
@@ -135,7 +135,7 @@ namespace Hinata.Controllers
             return PartialView("_DraftPreviewPartial", DraftPreviewViewModel.Create(draft, _parser));
         }
 
-        [HttpGet]
+        [HttpPost]
         [ValidateInput(false)]
         [Route("transform")]
         public ActionResult Transform(string markdown)

--- a/src/Hinata/Views/Draft/Edit.cshtml
+++ b/src/Hinata/Views/Draft/Edit.cshtml
@@ -135,7 +135,7 @@
             data.markdown = editorArea.value;
             $.ajax({
                 url: "@Url.Action("Transform", "Draft")",
-                type: "GET",
+                type: "POST",
                 dataType: "html",
                 data: data,
                 success: function (html) {


### PR DESCRIPTION
DraftController の Transform メソッドは POST で呼び出すように修正しました。
（Delete などの副作用のある操作も POST の方が良いかもです）
